### PR TITLE
Only check validity when remove wasn't a noop

### DIFF
--- a/Src/FluidCaching/Index.cs
+++ b/Src/FluidCaching/Index.cs
@@ -58,9 +58,11 @@ namespace FluidCaching
         public void Remove(TKey key)
         {
             INode<T> node = FindExistingNodeByKey(key);
-            node?.Remove();
-
-            lifespanManager.CheckValidity();
+            
+            if (node != null) {
+                node?.Remove();
+                lifespanManager.CheckValidity();
+            }
         }
 
         public long Count => index.Count;


### PR DESCRIPTION
There is no reason to check validity on noop operations.
