### PR TITLE
Fix overflow exception

### DIFF
--- a/FluidCaching.v3.ncrunchsolution
+++ b/FluidCaching.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/Src/FluidCaching/INode.cs
+++ b/Src/FluidCaching/INode.cs
@@ -7,6 +7,6 @@ namespace FluidCaching
     {
         T Value { get; }
         void Touch();
-        void Remove();
+        void RemoveFromCache();
     }
 }

--- a/Src/FluidCaching/Index.cs
+++ b/Src/FluidCaching/Index.cs
@@ -85,7 +85,7 @@ namespace FluidCaching
                     node = FindExistingNodeByKey(key);
                     if (node != null)
                     {
-                        node.Remove();
+                        node.RemoveFromCache();
 
                         lifespanManager.CheckValidity();
                     }

--- a/Src/FluidCaching/LifespanManager.cs
+++ b/Src/FluidCaching/LifespanManager.cs
@@ -7,6 +7,8 @@ namespace FluidCaching
 {
     internal class LifespanManager<T> : IEnumerable<INode<T>> where T : class
     {
+        private const int MaxItemsInBag = 20;
+        private const int EmptyBagsBuffer = 5;
         private readonly FluidCache<T> owner;
         private readonly TimeSpan minAge;
         private readonly GetNow getNow;
@@ -23,14 +25,21 @@ namespace FluidCaching
         public LifespanManager(FluidCache<T> owner, int capacity, TimeSpan minAge, TimeSpan maxAge, GetNow getNow)
         {
             this.owner = owner;
-            double maxMS = Math.Min(maxAge.TotalMilliseconds, (double) 12 * 60 * 60 * 1000); // max = 12 hours
             this.minAge = minAge;
             this.getNow = getNow;
-            this.maxAge = TimeSpan.FromMilliseconds(maxMS);
-            validatyCheckInterval = TimeSpan.FromMilliseconds(maxMS / 240.0); // max timeslice = 3 min
-            bagItemLimit = Math.Max(capacity / 20, 1); // max 5% of capacity per bag
 
-            const int nrBags = 265; // based on 240 timeslices + 20 bags for ItemLimit + 5 bags empty buffer
+            // NOTE: Max = 12 hours
+            this.maxAge = TimeSpan.FromMilliseconds(Math.Min(maxAge.TotalMilliseconds, (double) 12 * 60 * 60 * 1000));
+
+            // NOTE: Max timeslice = 3 min
+            validatyCheckInterval =
+                TimeSpan.FromMilliseconds(Math.Min(maxAge.TotalMilliseconds, (double) 12 * 60 * 60 * 1000) / 240);
+
+            // NOTE: Max 5% of capacity per bag
+            bagItemLimit = Math.Max(capacity / MaxItemsInBag, 1);
+
+            // NOTE: Based on 240 timeslices + 20 bags for ItemLimit + 5 bags empty buffer
+            const int nrBags = 240 + MaxItemsInBag + EmptyBagsBuffer;
             bags = new OrderedAgeBagCollection<T>(nrBags);
 
             Stats = new CacheStats(capacity, nrBags, bagItemLimit, minAge, this.maxAge, validatyCheckInterval);
@@ -45,7 +54,7 @@ namespace FluidCaching
         /// <summary>checks to see if cache is still valid and if LifespanMgr needs to do maintenance</summary>
         public void CheckValidity()
         {
-            // Note: Monitor.Enter(this) / Monitor.Exit(this) is the same as lock(this)... We are using Monitor.TryEnter() because it
+            // NOTE: Monitor.Enter(this) / Monitor.Exit(this) is the same as lock(this)... We are using Monitor.TryEnter() because it
             // does not wait for a lock, if lock is currently held then skip and let next Touch perform cleanup.
             if (RequiresCleanup && Monitor.TryEnter(this))
             {
@@ -89,49 +98,60 @@ namespace FluidCaching
                 int itemsAboveCapacity = Stats.Current - Stats.Capacity;
                 AgeBag<T> bag = bags[OldestBagIndex];
 
-                while (AlmostOutOfBags || bag.HasExpired(maxAge, now) ||
-                       (itemsAboveCapacity > 0 && bag.HasReachedMinimumAge(minAge, now)))
+                while (!HasProcessedAllBags && (AlmostOutOfBags || BagNeedsCleaning(bag, itemsAboveCapacity, now)))
                 {
-                    // cache is still too big / old so remove oldest bag
-                    Node<T> node = bag.First;
-                    bag.First = null;
+                    itemsAboveCapacity = CleanBag(bag, itemsAboveCapacity);
 
-                    while (node != null)
-                    {
-                        Node<T> next = node.Next;
-                        node.Next = null;
-                        if (node.Value != null && node.Bag != null)
-                        {
-                            if (node.Bag == bag)
-                            {
-                                // item has not been touched since bag was closed, so remove it from LifespanMgr
-                                ++itemsAboveCapacity;
-                                node.Remove();
-                            }
-                            else
-                            {
-                                // item has been touched and should be moved to correct age bag now
-                                node.Next = node.Bag.First;
-                                node.Bag.First = node;
-                            }
-                        }
-
-                        node = next;
-                    }
-
-                    bag = bags[++OldestBagIndex];
-
-                    if (HasProcessedAllBags)
-                    {
-                        break;
-                    }
+                    ++OldestBagIndex;
+                    bag = bags[OldestBagIndex];
                 }
 
-                OpenBag(++CurrentBagIndex);
+                ++CurrentBagIndex;
+                OpenBag(CurrentBagIndex);
 
                 EnsureIndexIsValid();
             }
         }
+
+        private static int CleanBag(AgeBag<T> bag, int itemsAboveCapacity)
+        {
+            Node<T> node = bag.First;
+            bag.First = null;
+
+            while (node != null)
+            {
+                Node<T> nextNode = node.Next;
+
+                node.Next = null;
+                if (node.Value != null && node.Bag != null)
+                {
+                    if (node.Bag == bag)
+                    {
+                        // item has not been touched since bag was closed, so remove it from LifespanMgr
+                        --itemsAboveCapacity;
+                        node.Remove();
+                    }
+                    else
+                    {
+                        // item has been touched and should be moved to correct age bag now
+                        node.Next = node.Bag.First;
+                        node.Bag.First = node;
+                    }
+                }
+
+                node = nextNode;
+            }
+            return itemsAboveCapacity;
+        }
+
+        private bool BagNeedsCleaning(AgeBag<T> bag, int itemsAboveCapacity, DateTime now)
+        {
+            return bag.HasExpired(maxAge, now) || (itemsAboveCapacity > 0 && bag.HasReachedMinimumAge(minAge, now));
+        }
+
+        private bool HasProcessedAllBags => (OldestBagIndex == CurrentBagIndex);
+
+        private bool AlmostOutOfBags => (CurrentBagIndex - OldestBagIndex) > (bags.Count - EmptyBagsBuffer);
 
         private void EnsureIndexIsValid()
         {
@@ -144,10 +164,6 @@ namespace FluidCaching
                 }
             }
         }
-        
-        private bool AlmostOutOfBags => (CurrentBagIndex - OldestBagIndex) > (bags.Count - 5);
-
-        private bool HasProcessedAllBags => (OldestBagIndex == CurrentBagIndex);
 
         public CacheStats Stats { get; }
 

--- a/Src/FluidCaching/Node.cs
+++ b/Src/FluidCaching/Node.cs
@@ -55,7 +55,7 @@ namespace FluidCaching
         /// <summary>
         /// Removes the object from node, thereby removing it from all indexes and allows it to be garbage collected
         /// </summary>
-        public void Remove()
+        public void RemoveFromCache()
         {
             if ((Bag != null) && (Value != null))
             {

--- a/Src/FluidCaching/OrderedAgeBagCollection.cs
+++ b/Src/FluidCaching/OrderedAgeBagCollection.cs
@@ -52,7 +52,7 @@ namespace FluidCaching
                 while (node != null)
                 {
                     Node<T> next = node.Next;
-                    node.Remove();
+                    node.RemoveFromCache();
                     node = next;
                 }
             }


### PR DESCRIPTION
Fixed an `OverflowException` that could in `LifespanManager.CleanUp` when the oldest bag and current bag are the same. This can happen when only a few items are added to the cache over a long period. 